### PR TITLE
[Android] 페이지 계산 시점에 폰트가 로딩되지 않아서 오차가 발생할 수 있는 문제 수정

### DIFF
--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -149,8 +149,16 @@ export default class Reader extends _Reader {
    * @returns {Number}, -1은 재요청이 필요함을 의미
    */
   calcPageCount() {
-    if (document.fonts && document.fonts.status) {
-      if (document.fonts.status !== 'loaded') {
+    if (document.fonts) {
+      // https://drafts.csswg.org/css-font-loading/#dom-fontfaceloadstatus-loading
+      // 사용된 적이 없는 Font : unloaded
+      // 로딩중인 Font : loading
+      // 로딩된 Font : loaded
+      // 로딩 실패한 Font : error
+      // document.fonts.status, ready는 신뢰할 수 없으므로 아래와 같은 방법으로 체크
+      const fontFaceLoadingStatusList =
+        Array.from(document.fonts.values()).map(fontFace => fontFace.status);
+      if (fontFaceLoadingStatusList.indexOf('loading') >= 0) {
         return -1;
       }
     }

--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -146,9 +146,15 @@ export default class Reader extends _Reader {
   }
 
   /**
-   * @returns {Number}
+   * @returns {Number}, -1은 재요청이 필요함을 의미
    */
   calcPageCount() {
+    if (document.fonts && document.fonts.status) {
+      if (document.fonts.status !== 'loaded') {
+        return -1;
+      }
+    }
+
     if (this.context.isScrollMode) {
       return Math.round(this.totalHeight / this.context.pageHeightUnit);
     }
@@ -157,7 +163,6 @@ export default class Reader extends _Reader {
     if (this.totalWidth < columnWidth) {
       // 가끔 total width가 0으로 넘어오는 경우가 있다. (커버 페이지에서 이미지가 그려지기 전에 호출된다거나)
       // 젤리빈에서는 0이 아닌 getWidth()보다 작은 값이 나오는 경우가 확인되었으며 재요청시 정상값 들어옴.
-      // (-1을 리턴하면 재요청을 진행하게됨)
       return -1;
     }
 

--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -156,8 +156,8 @@ export default class Reader extends _Reader {
       // 로딩된 Font : loaded
       // 로딩 실패한 Font : error
       // document.fonts.status, ready는 신뢰할 수 없으므로 아래와 같은 방법으로 체크
-      const fontFaceLoadingStatusList =
-        Array.from(document.fonts.values()).map(fontFace => fontFace.status);
+      const fontFaceLoadingStatusList = [];
+      document.fonts.forEach(fontFace => fontFaceLoadingStatusList.push(fontFace.status));
       if (fontFaceLoadingStatusList.indexOf('loading') >= 0) {
         return -1;
       }


### PR DESCRIPTION
우선 `document.fonts`를 사용할 수 있는 경우에 대해서만 대응하였습니다.

그 외의 경우(예를 들어 Android 4.4 버전 이하의 기기)에 대해서는 아래의 두 가지 방법을 확인해보았지만, 문제가 있어 대응을 보류하였습니다.
- `document.readyState === 'complete'` 인지 확인하는 방법
  - Chrome 62에서 `document.fonts.status`의 결과와 대조해보니 fontface를 여전히 불러오고 있는데도 위 값이 `true`가 반환되는 경우가 있는 것을 확인하였습니다. 즉, 신뢰할 수 없습니다.
- https://github.com/bramstein/fontfaceobserver 
  - Observing할 font family를 개별적으로 지정해주어야하는 단점이 있습니다.
  - `document.body`에 text element를 추가한 후, 폰트가 로딩됨에 따라 해당 element의 width가 변화하는지 추적하는 방식이라 DOM에 영향을 줍니다.
