### PR TITLE
터치로 페이지 넘김 반응 속도 개선

### DIFF
--- a/src/android/Handler.es6
+++ b/src/android/Handler.es6
@@ -4,15 +4,6 @@ import Util from './Util';
 export default class Handler extends _Handler {
   /**
    * @param {Number} x
-   * @returns {Boolean}
-   */
-  isInViewportWidth(x) {
-    const point = this.reader.adjustPoint(0, 0);
-    return x >= point.x && x <= point.x + this.reader.content.wrapper.clientWidth;
-  }
-
-  /**
-   * @param {Number} x
    * @param {Number} y
    * @param {String} nativePoints
    */

--- a/src/android/libs/find-polyfill.js
+++ b/src/android/libs/find-polyfill.js
@@ -1,0 +1,46 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    },
+    configurable: true,
+    writable: true
+  });
+}

--- a/src/common/_Handler.es6
+++ b/src/common/_Handler.es6
@@ -15,16 +15,6 @@ export default class _Handler extends _Object {
   }
 
   /**
-   * x가 viewport에 속하는지 확인한다.
-   *
-   * @param {Number} x
-   * @returns {Boolean}
-   */
-  isInViewportWidth(/* x */) {
-    return true;
-  }
-
-  /**
    * 해당 좌표에서 링크를 찾아서 반환한다.
    *
    * @param {Number} x
@@ -32,21 +22,16 @@ export default class _Handler extends _Object {
    * @returns {{node: Node, href: String, type: String}|null}
    */
   getLinkFromPoint(x, y) {
+    const point = this.reader.adjustPoint(x, y);
     const tolerance = 10;
-    const anchors = document.links;
-
-    for (let i = 0; i < anchors.length; i++) {
-      const rects = anchors[i].getClientRects();
-      for (let j = 0; j < rects.length; j++) {
-        if ((x >= rects[j].left - tolerance) && (x <= rects[j].right + tolerance) &&
-          (y >= rects[j].top - tolerance) && (y <= rects[j].bottom + tolerance)) {
-          const link = this.reader.content.getLinkFromElement(anchors[i]);
-          if (link !== null) {
-            return link;
-          }
-        }
-      }
-    }
-    return null;
+    const links = [].slice.call(document.links);
+    const predicate = (rect) => { // eslint-disable-line arrow-body-style
+      return (point.x >= rect.left - tolerance) && (point.x <= rect.right + tolerance) &&
+        (point.y >= rect.top - tolerance) && (point.y <= rect.bottom + tolerance);
+    };
+    return this.reader.content.getLinkFromElement(links.find((link) => {
+      const rects = link.getAdjustedClientRects();
+      return rects.find(predicate) !== undefined;
+    }));
   }
 }

--- a/src/common/_Handler.es6
+++ b/src/common/_Handler.es6
@@ -32,17 +32,17 @@ export default class _Handler extends _Object {
    * @returns {{node: Node, href: String, type: String}|null}
    */
   getLinkFromPoint(x, y) {
-    const point = this.reader.adjustPoint(x, y);
     const tolerance = 10;
-    for (let _x = point.x - tolerance; _x <= point.x + tolerance; _x += 1) {
-      for (let _y = point.y - tolerance; _y <= point.y + tolerance; _y += 1) {
-        if (this.isInViewportWidth(x)) {
-          const el = document.elementFromPoint(x, y);
-          if (el) {
-            const link = this.reader.content.getLinkFromElement(el);
-            if (link !== null) {
-              return link;
-            }
+    const anchors = document.links;
+
+    for (let i = 0; i < anchors.length; i++) {
+      const rects = anchors[i].getClientRects();
+      for (let j = 0; j < rects.length; j++) {
+        if ((x >= rects[j].left - tolerance) && (x <= rects[j].right + tolerance) &&
+          (y >= rects[j].top - tolerance) && (y <= rects[j].bottom + tolerance)) {
+          const link = this.reader.content.getLinkFromElement(anchors[i]);
+          if (link !== null) {
+            return link;
           }
         }
       }

--- a/src/ios/Handler.es6
+++ b/src/ios/Handler.es6
@@ -4,16 +4,6 @@ import Util from './Util';
 export default class Handler extends _Handler {
   /**
    * @param {Number} x
-   * @returns {Boolean}
-   */
-  isInViewportWidth(x) {
-    const startViewportWidth = 0;
-    const endViewportWidth = startViewportWidth + document.body.clientWidth;
-    return x >= startViewportWidth && x <= endViewportWidth;
-  }
-
-  /**
-   * @param {Number} x
    * @param {Number} y
    * @param {Number} rawX
    * @param {Number} rawY


### PR DESCRIPTION
현재 Handler. getLinkFromPoint(x, y) 함수에서
터치 포인트 및 주변 포인트들을 체크하여 터치된 링크가 있는지 확인하게 되어있는데,
사용 환경에 따라 이로 인한 딜레이가 발생하는 문제가 있습니다.

document.links 로 spine 내의 링크 목록을 가져오고,
해당되는 rect 내에 터치 포인트가 들어가는지 확인하는 방식으로 변경하였습니다.