### PR TITLE
터치로 페이지 넘김 반응 속도 개선 2

### DIFF
--- a/src/common/_Handler.es6
+++ b/src/common/_Handler.es6
@@ -23,16 +23,18 @@ export default class _Handler extends _Object {
    */
   getLinkFromPoint(x, y) {
     const point = this.reader.adjustPoint(x, y);
-    const tolerance = 10;
-    const links = [].slice.call(document.links);
-    const predicate = (rect) => { // eslint-disable-line arrow-body-style
-      return (point.x >= rect.left - tolerance) && (point.x <= rect.right + tolerance) &&
-        (point.y >= rect.top - tolerance) && (point.y <= rect.bottom + tolerance);
-    };
-    const element = links.find(link => link.getAdjustedClientRects().find(predicate) !== undefined);
-    if (element === undefined) {
-      return null;
+    const tolerance = 12;
+    for (let x = point.x - tolerance; x <= point.x + tolerance; x += 6) { // eslint-disable-line no-shadow
+      for (let y = point.y - tolerance; y <= point.y + tolerance; y += 6) { // eslint-disable-line no-shadow
+        const el = document.elementFromPoint(x, y);
+        if (el) {
+          const link = this.reader.content.getLinkFromElement(el);
+          if (link !== null) {
+            return link;
+          }
+        }
+      }
     }
-    return this.reader.content.getLinkFromElement(element);
+    return null;
   }
 }

--- a/src/common/_Handler.es6
+++ b/src/common/_Handler.es6
@@ -22,10 +22,15 @@ export default class _Handler extends _Object {
    * @returns {{node: Node, href: String, type: String}|null}
    */
   getLinkFromPoint(x, y) {
+    if (document.links.length === 0) {
+      return null;
+    }
+
     const point = this.reader.adjustPoint(x, y);
     const tolerance = 12;
-    for (let x = point.x - tolerance; x <= point.x + tolerance; x += 6) { // eslint-disable-line no-shadow
-      for (let y = point.y - tolerance; y <= point.y + tolerance; y += 6) { // eslint-disable-line no-shadow
+    const stride = 6;
+    for (let x = point.x - tolerance; x <= point.x + tolerance; x += stride) { // eslint-disable-line no-shadow
+      for (let y = point.y - tolerance; y <= point.y + tolerance; y += stride) { // eslint-disable-line no-shadow
         const el = document.elementFromPoint(x, y);
         if (el) {
           const link = this.reader.content.getLinkFromElement(el);
@@ -35,6 +40,7 @@ export default class _Handler extends _Object {
         }
       }
     }
+
     return null;
   }
 }


### PR DESCRIPTION
#20 의 논의 결과에 따라 터치 포인트 및 주변 포인트들을 체크하여 링크를 찾는 이전의 방식으로 원복하고, loop의 반복 횟수를 줄이되 기존과 동일한 영역을 커버할 수 있도록 수정하였습니다.

아래는 기존과 첫 개선, 두 번째 개선을 테스트한 결과입니다.

---

- 테스트 환경: PP1
- 스파인 용량: 479KB
- 링크 수: 1,292개

스파인의 앞 페이지에서 링크를 찾는데 실패하는 경우:

컬럼 수 | 기존 | 개선 1 | 개선 2
---|---|---|---
296 | 2.4097 | 0.2698 | 0.1366
1,257 | 5.6201 | 0.5468 | 0.3185
2,022 | 8.8603 | 0.7326 | 0.5022

스파인의 뒤 페이지에서 링크를 찾는데 실패하는 경우:

컬럼 수 | 기존 | 개선 1 | 개선 2
---|---|---|---
296 | 0.6708 | 0.2547 | 0.0380
1,257 | 1.5245 | 0.6421 | 0.0864
2,022 | 3.2245 | 0.7687 | 0.1827

---

- 테스트 환경: 6P
- 스파인 용량: 479KB
- 링크 수: 1,292개

링크를 찾는데 실패하는 경우:

컬럼 수 | 기존 | 개선 1 | 개선 2
---|---|---|---
403 | 0.4349 | 0.0759 | 0.0434
1,442 | 0.7149 | 0.0953 | 0.0673
2,316 | 0.8333 | 0.1018 | 0.0513
