### PR TITLE
만화 삽화가 여러 페이지에 걸쳐 나올때 발생하는 버그 수정

### DIFF
--- a/src/android/Handler.es6
+++ b/src/android/Handler.es6
@@ -51,12 +51,12 @@ export default class Handler extends _Handler {
     const point = this.reader.adjustPoint(x, y);
     let result = content.getImageFromPoint(point.x, point.y);
     if (result) {
-      const { left, top, width, height } = this.reader.rectToAbsolute(result.rect);
+      const { left, top, width, height } = result.rect;
       android.onImageFound(result.src, result.id, left, top, width, height);
     } else {
       result = content.getSvgFromPoint(point.x, point.y);
       if (result) {
-        const { left, top, width, height } = this.reader.rectToAbsolute(result.rect);
+        const { left, top, width, height } = result.rect;
         android.onSvgFound(result.html, result.id, left, top, width, height);
       }
     }

--- a/src/common/_Content.es6
+++ b/src/common/_Content.es6
@@ -135,7 +135,7 @@ export default class _Content extends _Object {
           mutable.left += left;
           mutable.top += top;
         } else if (left < 0) {
-          mutable.top -= height
+          mutable.top -= height;
         }
         mutable.height += height;
         return mutable;

--- a/src/common/_Content.es6
+++ b/src/common/_Content.es6
@@ -128,16 +128,18 @@ export default class _Content extends _Object {
         const mutable = result;
         const { left, right, top, height } = item;
         if (left <= x && x < right) {
-          mutable.left = left;
-          mutable.top = top;
+          mutable.left += left;
+          mutable.top += top;
         } else if (left >= 0 && x === undefined) {
           x = left; // eslint-disable-line no-param-reassign
-          mutable.left = left;
-          mutable.top = top;
+          mutable.left += left;
+          mutable.top += top;
+        } else if (left < 0) {
+          mutable.top -= height
         }
         mutable.height += height;
         return mutable;
-      }, new MutableClientRect({ left: rect.left, top: rect.top, width: rect.width }));
+      }, new MutableClientRect({ width: rect.width }));
 
       rect.right = rect.left + rect.width;
       rect.bottom = rect.top + rect.height;


### PR DESCRIPTION
### 개요
만화 삽화가 여러 페이지에 걸쳐 나올때 `android::onImageFound` 에서 좌표가 잘못 나오는 문제가 있습니다.
관련 이슈 : https://app.asana.com/0/72323656602719/1165464246759657/f

### 문제
1. widthxheight 값이 비정상적으로 나옴 : 다빈님이 526cf358dbb27ecfa4a305c5e1b29ee6481f0b8e 에서 수정해 주셨습니다.
2. left 좌표가 2배 크개 나오는 문제 : 보정이 2번 적용되고 있었습니다.
3. 짤린 삽화의 하단 부분에서 좌표 보정 : 비율을 맞추기 위해 (left, top) 좌표를 아래 이미지와 같이 수정하였습니다.
![스크린샷 2020-03-17 오후 1 38 38](https://user-images.githubusercontent.com/5474864/76822517-aac80c00-6854-11ea-9eef-fec1d53f9ff3.png)

/cc @sinoru 3번 참고 부탁드립니다!