### PR TITLE
TextNode의 첫 word가 white space로 시작할 때 wordIndex 값이 잘못 들어가는 문제 수정

### DIFF
--- a/src/common/tts/TTSChunk.es6
+++ b/src/common/tts/TTSChunk.es6
@@ -163,7 +163,7 @@ export default class TTSChunk {
       return 0;
     }
 
-    const words = (piece.node.nodeValue || '').split(TTSUtil.getSplitWordRegex());
+    const words = (piece.node.nodeValue.substring(this.range.startOffset, this.range.endOffset) || '').split(TTSUtil.getSplitWordRegex());
     let currentWordStartOffset = 0;
     for (let j = 0; j < words.length; j += 1) {
       if (currentWordStartOffset >= offsetBeforeWordInNode) {
@@ -207,7 +207,7 @@ export default class TTSChunk {
     // |-----------------------------------------|-End Word-|--------------------|
     const offsetAfterEndWordInNode = (this.range.endOffset + firstPaddingLeft) - offsetBeforeNode;
 
-    const words = (piece.node.nodeValue || '').split(TTSUtil.getSplitWordRegex());
+    const words = (piece.node.nodeValue.substring(this.range.startOffset, this.range.endOffset) || '').split(TTSUtil.getSplitWordRegex());
     let currentWordEndOffset = 0;
     for (let j = 0; j < words.length; j += 1) {
       currentWordEndOffset += (words[j].length + 1);

--- a/src/common/tts/TTSChunk.es6
+++ b/src/common/tts/TTSChunk.es6
@@ -148,6 +148,7 @@ export default class TTSChunk {
     for (let i = 0; i < this._pieces.length; i += 1) {
       const currentPiece = this._pieces[i];
       if (currentPiece.nodeIndex >= piece.nodeIndex) {
+        offsetBeforeNode += currentPiece.text.search(/\S/);
         break;
       } else {
         // piece.length는 piece.text.length와 같다.
@@ -169,7 +170,7 @@ export default class TTSChunk {
       if (currentWordStartOffset >= offsetBeforeWordInNode) {
         return j;
       }
-      currentWordStartOffset += (words[j].length + 1);
+      currentWordStartOffset += (words[j].trim().length + 1);
     }
     return words.length - 1;
   }

--- a/src/common/tts/TTSChunk.es6
+++ b/src/common/tts/TTSChunk.es6
@@ -163,7 +163,7 @@ export default class TTSChunk {
       return 0;
     }
 
-    const words = (piece.node.nodeValue.substring(this.range.startOffset, this.range.endOffset) || '').split(TTSUtil.getSplitWordRegex());
+    const words = (piece.node.nodeValue || '').split(TTSUtil.getSplitWordRegex());
     let currentWordStartOffset = 0;
     for (let j = 0; j < words.length; j += 1) {
       if (currentWordStartOffset >= offsetBeforeWordInNode) {
@@ -207,7 +207,7 @@ export default class TTSChunk {
     // |-----------------------------------------|-End Word-|--------------------|
     const offsetAfterEndWordInNode = (this.range.endOffset + firstPaddingLeft) - offsetBeforeNode;
 
-    const words = (piece.node.nodeValue.substring(this.range.startOffset, this.range.endOffset) || '').split(TTSUtil.getSplitWordRegex());
+    const words = (piece.node.nodeValue || '').split(TTSUtil.getSplitWordRegex());
     let currentWordEndOffset = 0;
     for (let j = 0; j < words.length; j += 1) {
       currentWordEndOffset += (words[j].length + 1);


### PR DESCRIPTION
### 개요

예시 TextNode (줄넘김으로 시작): 
```

1. 이동은 헬기나 배로
```

White space 단위로 word 가 분리되지만 첫 word 앞의 white space 는 제거되지 않으므로 rangeStartOffset은 1이 되지만 `offsetBeforeNode`에는 반영되지 않아 이후 `offsetBeforeWordInNode` 계산 시에 +-0 로 상쇄되지 않음
->
같은 이유로 그 아래 word 단위 루프에서 바로 종료되지 않고 한번 더 돌게 되면서 첫 word인 `1.` 의 wordIndex는 그 다음 word인 `이동은`과 동일하게 처리됨
->
네이티브단에서 `getStartWordIndex()`의 결과값만 사용하다보니 결과적으로 두 문장 `1.`/`이동은 헬기나 배로` 는 동일한 nodeIndex / wordIndex 를 가지게 됨

문제를 해결하기 위해 wordIndex 계산 시에 white space 로 시작하는 경우 `offsetBeforeNode`에 반영하여 문제 시나리오에서 정상적으로 0을 리턴할 수 있도록 함
추가로 아래 word 단위 루프에서도 trim() 한 length 를 사용하여 마지막 word 가 잘리지 않도록 함

AS-IS
```
utteranceList[0]=(2,1) 1.
utteranceList[1]=(2,1) 이동은 헬기나 배로
```
TO-BE
```
utteranceList[0]=(2,0) 1.
utteranceList[1]=(2,1) 이동은 헬기나 배로
```
