### PR TITLE
안드로이드 스크롤 보정식 수정

### DIFF
--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -102,11 +102,7 @@ export default class Reader extends _Reader {
       const height = this.context.pageHeightUnit;
       const paddingTop = Util.getStylePropertyIntValue(body, 'padding-top');
       const paddingBottom = Util.getStylePropertyIntValue(body, 'padding-bottom');
-      const maxOffset = this.totalHeight - height - paddingBottom;
-      const diff = maxOffset - adjustOffset;
-      if (adjustOffset > paddingTop && diff < height && diff > 0) {
-        adjustOffset = maxOffset;
-      }
+      const maxOffset = Math.max(this.totalHeight - height - paddingBottom, paddingTop);
       adjustOffset = Math.min(adjustOffset, maxOffset);
     } else if (this.calcPageCount() > -1) {
       const width = this.context.pageWidthUnit;


### PR DESCRIPTION
## 요약

- 잘못된 보정식으로 인해 스크롤 보기에서의 듣기 이용 시 스파인 마지막 페이지에서 잘못된 위치로 고정되어 보이는 문제를 수정합니다.
  - 네이티브에서 들어온 offset과 상한선을 고려한 maxOffset 사이의 차이가 뷰포트 높이보다 적은 경우 maxOffset으로 고정하도록 되어 있는데 굳이 이럴 필요가 없어 제거합니다.
  - 부수적으로 본문이 뷰포트 높이보다 작은 경우 상하 여백을 maxOffset으로 잡도록 해 본문의 시작 지점보다 올라가지 않도록 합니다.

## 작업 내용

- 잘못된 보정식을 수정 했습니다.

## 관련 링크

- [[APP] Android > 스크롤 보기 중 TTS 실행 시 스크롤 이슈](https://app.asana.com/0/1204830265563801/1204877934157969/f)