### PR TITLE
[AOS] 본문의 script 읽는 오류 수정

### DIFF
--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -121,6 +121,10 @@ export default class TTSPiece {
             valid = false;
             break;
           }
+          if (el.nodeName.toLocaleLowerCase() === 'script') {
+            valid = false;
+            break;
+          }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {
             break;


### PR DESCRIPTION
## 요약 및 작업내용
- TTS 재생중 본문의 script를 읽는 이슈를 대응합니다.

## 관련 이슈
- [[APP] 뷰어 내의 삽화(표지) 페이지에서 TTS 실행 시 주석 코드가 발화 됨](https://app.asana.com/0/1205645819288315/1205713371818925/f)
