### PR TITLE
안드로이드 스케일 이슈 대응

### DIFF
--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -246,6 +246,11 @@ export default class Reader extends _Reader {
     }
   }
 
+  getDefaultScale() {
+    const { nativeDenstiy, isScrollMode } = this.context;
+    return isScrollMode ? 1 : nativeDenstiy / window.devicePixelRatio;
+  }
+
   /**
    * @param {Number} width
    * @param {Number} height

--- a/src/common/_Context.es6
+++ b/src/common/_Context.es6
@@ -22,6 +22,11 @@ export default class _Context extends _Object {
   get pageUnit() { return this.isScrollMode ? this.pageHeightUnit : this.pageWidthUnit; }
 
   /**
+   * @returns {Number}
+   */
+  get nativeDenstiy() { return this._nativeDenstiy; }
+
+  /**
    * @returns {Boolean}
    */
   get isDoublePageMode() { return this._doublePageMode; }
@@ -45,16 +50,18 @@ export default class _Context extends _Object {
    * @param {Number} width
    * @param {Number} height
    * @param {Number} gap
+   * @param {Number} nativeDenstiy
    * @param {Boolean} doublePageMode
    * @param {Boolean} scrollMode
    * @param {Number} maxSelectionLength
    * @param {Number} systemMajorVersion
    */
-  constructor(width, height, gap, doublePageMode, scrollMode, maxSelectionLength = 0, systemMajorVersion = 0) {
+  constructor(width, height, gap, nativeDenstiy, doublePageMode, scrollMode, maxSelectionLength = 0, systemMajorVersion = 0) {
     super();
     this._width = width;
     this._height = height;
     this._gap = gap;
+    this._nativeDenstiy = nativeDenstiy;
     this._doublePageMode = doublePageMode;
     this._scrollMode = scrollMode;
     this._maxSelectionLength = maxSelectionLength;

--- a/src/common/_Reader.es6
+++ b/src/common/_Reader.es6
@@ -108,9 +108,15 @@ export default class _Reader extends _Object {
     /* eslint-enable no-param-reassign */
   }
 
+  getDefaultScale() {
+    return 1;
+  }
+
   setViewport() {
-    const value = `width=${this.context.pageWidthUnit - this.context.pageGap}, height=${this.context.pageHeightUnit},` +
-      ' initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0';
+    const scale = this.getDefaultScale();
+    const value = 'width=device-width, height=device-height, ' +
+      `initial-scale=${scale}, maximum-scale=${scale}, minimum-scale=${scale}, ` +
+      'user-scalable=0';
     let viewport = document.querySelector('meta[name=viewport]');
     if (viewport === null) {
       viewport = document.createElement('meta');


### PR DESCRIPTION
## 요약

- 특정 기기에서 네이티브 denstiy와 웹뷰 denstiy가 불일치할 때 축소되어 본문이 노출되는 문제를 대응합니다.
- Context로 주입된 수치는 네이티브 denstiy로 계산되어 있기 때문에 웹뷰 denstiy가 네이티브와 다른 경우 축소되거나 확대되어 보일 수 있습니다.
- 이 문제를 대응하기 위해 네이티브에서 웹뷰 스케일을 조정하지만 특정 기기에서는 효과가 없어 뷰포트 스케일을 직접 조정합니다.

## 작업 내용

- Context에 nativeDenstiy 프로퍼티를 추가 했습니다.
- 안드 한정으로 뷰포트 스케일을 상황에 맞게 커스텀 해 사용하도록 수정 했습니다.