### PR TITLE
totalSize 계산에 보정식 추가

### DIFF
--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -22,6 +22,24 @@ export default class Reader extends _Reader {
   get bodyClientWidth() { return this._bodyClientWidth; }
 
   /**
+   * @returns {Number}
+   */
+  get totalWidth() {
+    const marginLeft = Util.getStylePropertyIntValue(this.content.wrapper, 'margin-left');
+    const marginRight = Util.getStylePropertyIntValue(this.content.wrapper, 'margin-right');
+    return super.totalWidth - (marginLeft + marginRight);
+  }
+
+  /**
+   * @returns {Number}
+   */
+  get totalHeight() {
+    const marginTop = Util.getStylePropertyIntValue(this.content.wrapper, 'margin-top');
+    const marginBottom = Util.getStylePropertyIntValue(this.content.wrapper, 'margin-bottom');
+    return super.totalHeight - (marginTop + marginBottom);
+  }
+
+  /**
    * @param {HTMLElement} wrapper
    * @param {Context} context
    * @param {Number} curPage (zero-base)


### PR DESCRIPTION
## 요약

- react-native-epub-reader는 기존 리디 뷰어와 달리 여백을 네이티브가 아닌 웹뷰에서 CSS로 처리하도록 되어있어 뷰어 여백 설정 시 `documentElement`에 여백이 추가되고 있습니다.
- `totlaSize`는 `wrapper`의 `scrollWidth/Height`를 리턴하도록 되어있는데 웹뷰에 단일 스파인을 로드하는 뷰어 구현 방식에서 `wrapper`는 `documentElement`라서 여백이 추가 되게 됩니다.
- 안드로이드에서는 페이지 계산을 `totalSize`를 `pageUnit`으로 나누고 있어 추가된 여백으로 인해 페이징 오차가 발생하게 되어 이 여백을 제외하고 계산할 수 있도록 보정식을 추가합니다.

## 작업 내용

- `totlaSize`에서 여백을 제외하고 리턴하도록 수정 했습니다.