### PR TITLE
안드로이드 스케일 이슈 재대응

### DIFF
--- a/src/android/Reader.es6
+++ b/src/android/Reader.es6
@@ -265,8 +265,7 @@ export default class Reader extends _Reader {
   }
 
   getDefaultScale() {
-    const { nativeDenstiy, isScrollMode } = this.context;
-    return isScrollMode ? 1 : nativeDenstiy / window.devicePixelRatio;
+    return this.context.nativeDenstiy / window.devicePixelRatio;
   }
 
   /**


### PR DESCRIPTION
## 요약

- 사이드 이펙트를 최소화하기 위해 #37 에서 스크롤 보기는 예외 처리를 했었고 당시 테스트 환경에서는 이상이 없었으나, Z플립 커버 디시플레이에서 다시 재현되기 시작해 스크롤 보기까지 확대 적용합니다.

## 작업 내용

- 스크롤 보기에서도 적절한 스케일로 뷰포트를 설정하도록 수정 했습니다.

## 관련 링크

- [230802_[AOS 23.5.5] 보기설정 > 문단 너비 설정에 따라 본문이 왼쪽으로 치우침](https://app.asana.com/0/1200685351973138/1205190116945147/f)