### PR TITLE
[안드] 듣기시 유효하지 않은 span태그 스킵하도록

### DIFF
--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -137,10 +137,18 @@ export default class TTSPiece {
               el.parentNode.nodeName.toLowerCase() === 'span' &&
               (el.previousSibling || el.nextSibling);
             // 부모의 자식 노드들 중 유효한 텍스트가 있는지 확인
-            const hasValidSiblingContent = el.parentNode && Array.from(el.parentNode.childNodes).some(childNode => (
-              (childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
-              (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')
-            ));
+            let hasValidSiblingContent = false;
+            if (el.parentNode && el.parentNode.childNodes) {
+              const { childNodes } = el.parentNode;
+              for (let i = 0; i < childNodes.length; i++) {
+                const childNode = childNodes[i];
+                if ((childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
+                    (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')) {
+                  hasValidSiblingContent = true;
+                  break;
+                }
+              }
+            }
 
             if (isEmptyText && (hasNoChildren || (!hasValidParentAndSiblings && !hasValidSiblingContent))) {
               valid = false;

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -126,34 +126,9 @@ export default class TTSPiece {
             break;
           }
           // 공백만 있는 span 태그 읽지 않도록
-          if (el.nodeName.toLowerCase() === 'span') {
-            // 텍스트가 공백인 경우
-            const isEmptyText = this._text.trim() === '';
-            // 자식 노드가 없는 경우
-            const hasNoChildren = !el.hasChildNodes();
-            // 부모가 span이고 형제 노드가 있는 경우 유효하다고 판단
-            const hasValidParentAndSiblings =
-              el.parentNode &&
-              el.parentNode.nodeName.toLowerCase() === 'span' &&
-              (el.previousSibling || el.nextSibling);
-            // 부모의 자식 노드들 중 유효한 텍스트가 있는지 확인
-            let hasValidSiblingContent = false;
-            if (el.parentNode && el.parentNode.childNodes) {
-              const { childNodes } = el.parentNode;
-              for (let i = 0; i < childNodes.length; i++) {
-                const childNode = childNodes[i];
-                if ((childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
-                    (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')) {
-                  hasValidSiblingContent = true;
-                  break;
-                }
-              }
-            }
-
-            if (isEmptyText && (hasNoChildren || (!hasValidParentAndSiblings && !hasValidSiblingContent))) {
-              valid = false;
-              break;
-            }
+          if (el.nodeName.toLowerCase() === 'span' && el.innerText.trim().length === 0) {
+            valid = false;
+            break;
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -126,9 +126,26 @@ export default class TTSPiece {
             break;
           }
           // 공백만 있는 span 태그 읽지 않도록
-          if (el.nodeName.toLowerCase() === 'span' && this._text.trim() === '') {
-            valid = false;
-            break;
+          if (el.nodeName.toLowerCase() === 'span') {
+            // 텍스트가 공백인 경우
+            const isEmptyText = this._text.trim() === '';
+            // 자식 노드가 없는 경우
+            const hasNoChildren = !el.hasChildNodes();
+            // 부모가 span이고 형제 노드가 있는 경우 유효하다고 판단
+            const hasValidParentAndSiblings =
+              el.parentNode &&
+              el.parentNode.nodeName.toLowerCase() === 'span' &&
+              (el.previousSibling || el.nextSibling);
+            // 부모의 자식 노드들 중 유효한 텍스트가 있는지 확인
+            const hasValidSiblingContent = el.parentNode && Array.from(el.parentNode.childNodes).some(childNode => (
+              (childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
+              (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')
+            ));
+
+            if (isEmptyText && (hasNoChildren || (!hasValidParentAndSiblings && !hasValidSiblingContent))) {
+              valid = false;
+              break;
+            }
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,6 +125,11 @@ export default class TTSPiece {
             valid = false;
             break;
           }
+          // 공백만 있는 span 태그 읽지 않도록
+          if (el.nodeName.toLowerCase() === 'span' && this._text.trim() === '') {
+            valid = false;
+            break;
+          }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {
             break;

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -137,10 +137,18 @@ export default class TTSPiece {
               el.parentNode.nodeName.toLowerCase() === 'span' &&
               (el.previousSibling || el.nextSibling);
             // 부모의 자식 노드들 중 유효한 텍스트가 있는지 확인
-            const hasValidSiblingContent = el.parentNode && Array.from(el.parentNode.childNodes || []).some(childNode => (
-              (childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
-              (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')
-            ));
+            let hasValidSiblingContent = false;
+            if (el.parentNode && el.parentNode.childNodes) {
+              const { childNodes } = el.parentNode;
+              for (let i = 0; i < childNodes.length; i++) {
+                const childNode = childNodes[i];
+                if ((childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
+                    (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')) {
+                  hasValidSiblingContent = true;
+                  break;
+                }
+              }
+            }
 
             if (isEmptyText && (hasNoChildren || (!hasValidParentAndSiblings && !hasValidSiblingContent))) {
               valid = false;

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -137,18 +137,10 @@ export default class TTSPiece {
               el.parentNode.nodeName.toLowerCase() === 'span' &&
               (el.previousSibling || el.nextSibling);
             // 부모의 자식 노드들 중 유효한 텍스트가 있는지 확인
-            let hasValidSiblingContent = false;
-            if (el.parentNode && el.parentNode.childNodes) {
-              const { childNodes } = el.parentNode;
-              for (let i = 0; i < childNodes.length; i++) {
-                const childNode = childNodes[i];
-                if ((childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
-                    (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')) {
-                  hasValidSiblingContent = true;
-                  break;
-                }
-              }
-            }
+            const hasValidSiblingContent = el.parentNode && Array.from(el.parentNode.childNodes || []).some(childNode => (
+              (childNode.nodeType === Node.TEXT_NODE && childNode.nodeValue.trim() !== '') ||
+              (childNode.nodeType === Node.ELEMENT_NODE && childNode.textContent.trim() !== '')
+            ));
 
             if (isEmptyText && (hasNoChildren || (!hasValidParentAndSiblings && !hasValidSiblingContent))) {
               valid = false;

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -107,7 +107,7 @@ export default class TTSPiece {
     const readable = (el.attributes['data-ridi-tts'] || { value: '' }).value.toLowerCase();
     let valid = true;
 
-    if (this.length === 0 || readable === 'no') {
+    if (this.length === 0 || el.innerText.trim().length === 0 || readable === 'no') {
       valid = false;
     } else if (readable !== 'yes') {
       if (_Util.getMatchedCSSValue(el, 'display') === 'none'
@@ -122,11 +122,6 @@ export default class TTSPiece {
             break;
           }
           if (el.nodeName.toLocaleLowerCase() === 'script') {
-            valid = false;
-            break;
-          }
-          // 공백만 있는 span 태그 읽지 않도록
-          if (el.nodeName.toLowerCase() === 'span' && el.innerText.trim().length === 0) {
             valid = false;
             break;
           }


### PR DESCRIPTION
## 요약 및 작업내용
- 공백만 있는 span 태그로 chunk를 만드는데 null로 만들어져 읽을 수 없는 문제가 있습니다.
- ~d3c50c73a26a667466a1dd74b5cf535cf438da37 공백 span 태그는 읽기 스킵하도록 합니다.~ 142, 143 테스트케이스 실패
- ~87011b08a08e9b921730a847a4df0c9bf7ac1c55 유효하지 공백 span 태그는 읽기 스킵하도록 합니다.~ 는 생성자이슈로 테스트케이스 실패
- 2e55b61ec216259fce590bd9da3226ad5baf6c6d 유효하지 공백 span 태그는 읽기 스킵하도록 합니다.

## 문제가 되는 도서 예시
```html
...
<p class="장시작">
  <img alt="PHOTO3" src="../Images/PHOTO3.jpg" style="color: rgb(0, 187, 206); font-family: 'SD Gothic Std', sans-serif; font-size: 1.583em; line-height: 1.158;">
  <span style="font-size: 1em; line-height: 1.833;">&nbsp;</span>
  <br>
</p>
<p class="본문">&nbsp;</p>
...
```

## 참고사항
- 수정후 문제가 발생하지 않음을 확인했습니다.
- [[CS] <대화로 푸는 전도서> 듣기 시 챕터 이동이 안되는 문제 확인 요청](https://app.asana.com/0/1200685351973138/1208499575279168/f)