### PR TITLE
빈 텍스트로 셀렉션이 시작될 수 있는 문제 수정

### DIFF
--- a/src/common/_Sel.es6
+++ b/src/common/_Sel.es6
@@ -115,6 +115,10 @@ export default class _Sel extends _Object {
     // 처음 선택시에는 붙어있는 특수문자까지 모두 포함시킨다
     this._expandRangeByWord(range);
 
+    if (!range.toString().length) {
+      return false;
+    }
+
     this._startContainer = range.startContainer;
     this._startOffset = range.startOffset;
     this._endContainer = range.endContainer;


### PR DESCRIPTION
## 작업 내용

- 셀렉트 시작을 위해 선택한 범위에 문자열이 없는 경우 셀렉션 시작을하지 않도록 수정 했습니다.

## 관련 링크

- [[APP][Android] ePub 뷰어 > 이미지에 형광펜 등록 가능](https://app.asana.com/0/1209139237519474/1209520065170265)