### PR TITLE
[안드] TTS Piece inValid 체크 중 리소스 문제로 크래시할 수 있는 문제 수정

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Set up node_modules cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: node-cache
       with:
         path: 'node_modules'
@@ -51,7 +51,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Set up node_modules cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: node-cache
       with:
         path: 'node_modules'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -65,7 +65,7 @@ jobs:
       run: yarn build
 
     - name: Checkout test repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ridi/Reader.js-TTS-Unit-Test
         ssh-key: ${{ secrets.TEST_ACCESS_PRIVATE_KEY }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -65,7 +65,7 @@ jobs:
       run: yarn build
 
     - name: Checkout test repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
       with:
         repository: ridi/Reader.js-TTS-Unit-Test
         ssh-key: ${{ secrets.TEST_ACCESS_PRIVATE_KEY }}

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,24 +125,9 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE) {
-            if (el._cachedEmptyState !== undefined) {
-              if (el._cachedEmptyState === true) {
-                valid = false;
-                break;
-              }
-            } else {
-              try {
-                const isEmpty = el.innerText.trim().length === 0;
-                el._cachedEmptyState = isEmpty;
-                if (isEmpty) {
-                  valid = false;
-                  break;
-                }
-              } catch (e) {
-                el._cachedEmptyState = false;
-              }
-            }
+          if (el && el.nodeType === Node.ELEMENT_NODE && el.innerText.trim().length === 0) {
+            valid = false;
+            break;
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,9 +125,24 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (this._text.trim().length === 0) {
-            valid = false;
-            break;
+          if (el && el.nodeType === Node.ELEMENT_NODE) {
+            if (el._cachedEmptyState !== undefined) {
+              if (el._cachedEmptyState === true) {
+                valid = false;
+                break;
+              }
+            } else {
+              try {
+                const isEmpty = el.innerText.trim().length === 0;
+                el._cachedEmptyState = isEmpty;
+                if (isEmpty) {
+                  valid = false;
+                  break;
+                }
+              } catch (e) {
+                el._cachedEmptyState = false;
+              }
+            }
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,24 +125,9 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE) {
-            if (el._cachedEmptyState !== undefined) {
-              if (el._cachedEmptyState === true) {
-                valid = false;
-                break;
-              }
-            } else {
-              try {
-                const isEmpty = el.textContent.trim().length === 0;
-                el._cachedEmptyState = isEmpty;
-                if (isEmpty) {
-                  valid = false;
-                  break;
-                }
-              } catch (e) {
-                el._cachedEmptyState = false;
-              }
-            }
+          if (el && el.nodeType === Node.ELEMENT_NODE && el.textContent.trim().length === 0) {
+            valid = false;
+            break;
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,9 +125,24 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE && el.textContent.trim().length === 0) {
-            valid = false;
-            break;
+          if (el && el.nodeType === Node.ELEMENT_NODE) {
+            if (el._cachedEmptyState !== undefined) {
+              if (el._cachedEmptyState === true) {
+                valid = false;
+                break;
+              }
+            } else {
+              try {
+                const isEmpty = el.textContent.trim().length === 0;
+                el._cachedEmptyState = isEmpty;
+                if (isEmpty) {
+                  valid = false;
+                  break;
+                }
+              } catch (e) {
+                el._cachedEmptyState = false;
+              }
+            }
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,7 +125,7 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE && el.innerText.trim().length === 0) {
+          if (this._text.trim().length === 0) {
             valid = false;
             break;
           }

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -125,7 +125,7 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE && el.textContent.trim().length === 0) {
+          if (el && el.nodeType === Node.ELEMENT_NODE && el.innerText.trim().length === 0) {
             valid = false;
             break;
           }


### PR DESCRIPTION
## 요약
- #42 에서 공백을 스킵하지 못하는 문제를 대응했는데, 이때 textContent를 사용해 노드의 유효성을 확인하도록 했지만 노드를 순회하면서 렌더링이 발생해 안드에서 특정 조건에서 리소스문제로 렌더링이 비정상종료됨에 따라 크래시하는 문제가 있습니다.

## 작업내용
- textContent 대신 innerText를 사용하도록 수정합니다.
- [19b846a](https://github.com/ridi/Reader.js/pull/45/commits/19b846aae7e2d7c34955e5a4ea9a21152b619d51) [actions/cache 버전문제 실패](https://github.com/ridi/Reader.js/actions/runs/14031835432/job/39280974524?pr=45) 에 따라 cache버전을 v4로 범핑합니다.

## 참고사항
- [스레드](https://ridi.slack.com/archives/C018YEHTPHS/p1742549546121849)
- [[APP][Android] TTS 재생 중 종료](https://app.asana.com/0/1209360978985214/1209746164224326/f)

