### PR TITLE
bump actions/checkout version v2 -> v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
@@ -65,7 +65,7 @@ jobs:
       run: yarn build
 
     - name: Checkout test repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ridi/Reader.js-TTS-Unit-Test
         ssh-key: ${{ secrets.TEST_ACCESS_PRIVATE_KEY }}


### PR DESCRIPTION
## 요약 및 작업내용
- eaba24c3c42a24eb28d25326208cfdf5ca6f1eba actions/checkout 버전을 v2를 사용하고 있는데 [지원이 종료됨](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)에 따라 v4로 범핑합니다.
