### PR TITLE
isInvalid 확인에 캐싱을 추가하고 프로퍼티로 관리해 생성자에서 처리하도록

### DIFF
--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -129,24 +129,9 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE) {
-            if (el._cachedEmptyState !== undefined) {
-              if (el._cachedEmptyState === true) {
-                valid = false;
-                break;
-              }
-            } else {
-              try {
-                const isEmpty = el.innerText.trim().length === 0;
-                el._cachedEmptyState = isEmpty;
-                if (isEmpty) {
-                  valid = false;
-                  break;
-                }
-              } catch (e) {
-                el._cachedEmptyState = false;
-              }
-            }
+          if (el && el.nodeType === Node.TEXT_NODE && el.innerText.trim().length === 0) {
+            valid = false;
+            break;
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {

--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -129,7 +129,7 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.TEXT_NODE && el.innerText.trim().length === 0) {
+          if (el && el.nodeType === Node.ELEMENT_NODE && el.innerText.trim().length === 0) {
             valid = false;
             break;
           }


### PR DESCRIPTION
## 요약 및 작업내용
- #45 에서 렌더링 크래시를 개선했지만 여전히 불특정 기기에서 동일한 크래시가 확인되어 재대응합니다.
- b14f2c56755c5b8fcc2ee9c497d351cdf9b79fe1 캐싱을 추가하고 invalid 확인을 생성자에서 노드가 생성될때 처리하고 프로퍼티로 관리하도록 합니다.