### PR TITLE
렌더링 충돌 관련 캐싱 다시 추가 (..)

### DIFF
--- a/src/common/tts/TTSPiece.es6
+++ b/src/common/tts/TTSPiece.es6
@@ -129,9 +129,24 @@ export default class TTSPiece {
             valid = false;
             break;
           }
-          if (el && el.nodeType === Node.ELEMENT_NODE && el.innerText.trim().length === 0) {
-            valid = false;
-            break;
+          if (el && el.nodeType === Node.ELEMENT_NODE) {
+            if (el._cachedEmptyState !== undefined) {
+              if (el._cachedEmptyState === true) {
+                valid = false;
+                break;
+              }
+            } else {
+              try {
+                const isEmpty = el.innerText.trim().length === 0;
+                el._cachedEmptyState = isEmpty;
+                if (isEmpty) {
+                  valid = false;
+                  break;
+                }
+              } catch (e) {
+                el._cachedEmptyState = false;
+              }
+            }
           }
           // 이미지, 독음(후리가나)과 첨자는 읽지 않는다
           if (!(valid = (['RT', 'RP', 'SUB', 'SUP', 'IMG'].indexOf(el.nodeName) === -1))) {


### PR DESCRIPTION
## 요약 및 작업내용
- #49 에서 isInvalid 호출자체를 생성자로 옮겨 호출횟수를 줄였지만, 노드 구조상 parentNode 하위에 여러 노드가 있을때 렌더링자체는 그대로일 수 있어 여전히 특정 기기에서 렌더링 크래시하는 문제가 있습니다 (..)
- 0f63538e7656ad5c538a84007a4295de0d0e61d5 isInvalid체크시점은 생성자에 그대로 두고, 처음 시도하고자 했던 방법으로 돌아가 캐싱을 추가합니다.
  - 이 방법으로 문제가 되는 기기에서 괜찮은 것 확인했습니다.